### PR TITLE
fix(98): Update configuration for liveness and readiness probe spring 2.3.2

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
-      
+
 springdoc:
   api-docs.enabled: false
 
@@ -32,7 +32,9 @@ management:
       exposure:
         include: 'info,health,prometheus'
   health:
-    probes:
+    livenessstate:
+      enabled: true
+    readynessstate:
       enabled: true
   endpoint:
     prometheus:
@@ -45,4 +47,6 @@ management:
           include:
             - readinessState
             - clamaAvConnection
+      probes:
+        enabled: true
 


### PR DESCRIPTION
Fix issue #98 
Update configuration for liveness and readiness probe to be compatible with spring boot 2.3.2
Ref:
- https://github.com/spring-projects/spring-boot/issues/22483
- https://www.baeldung.com/spring-liveness-readiness-probes#:~:text=As%20of%20Spring%20Boot%202.3%2C%20LivenessStateHealthIndicator%20and%20ReadinessStateHealthIndicator,Spring%20Boot%20will%20automatically%20register%20these%20health%20indicators.